### PR TITLE
Make 'get' raise a KeyError when the given key does not exist.

### DIFF
--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -7,6 +7,10 @@ from handlers.file_handler import FileHandler
 from handlers.ini_handler import IniHandler
 
 
+# An unique object we can check against.
+SENTINEL = object()
+
+
 class Kaptan(object):
 
     HANDLER_MAP = {
@@ -29,11 +33,11 @@ class Kaptan(object):
         self.configuration_data = self.handler.load(value)
         return self
 
-    def get(self, key):
+    def get(self, key, default=SENTINEL):
         current_data = self.configuration_data
         for chunk in key.split('.'):
             try:
-                current_data = current_data.get(chunk, {})
+                current_data = current_data.get(chunk, SENTINEL)
             except AttributeError as error:
                 if isinstance(current_data, list):
                     try:
@@ -44,6 +48,11 @@ class Kaptan(object):
                     return current_data[chunk]
                 else:
                     raise error
+            else:
+                if current_data is SENTINEL:
+                    if default is SENTINEL:
+                        raise KeyError(key)
+                    return default
 
         return current_data
 

--- a/tests.py
+++ b/tests.py
@@ -43,6 +43,18 @@ class KaptanTests(unittest.TestCase):
 
         self.assertEqual(config.get('servers.0'), 'redis1')
 
+    def test_keyerror(self):
+        config = kaptan.Kaptan()
+        config.import_config(self.__get_config_data())
+
+        self.assertRaises(KeyError, config.get, 'doesnotexist')
+
+    def test_default(self):
+        config = kaptan.Kaptan()
+        config.import_config(self.__get_config_data())
+
+        self.assertEqual(config.get('doesnotexist', 'defaultvalue'), 'defaultvalue')
+
     def test_upsert(self):
         config = kaptan.Kaptan()
         config.import_config(self.__get_config_data())


### PR DESCRIPTION
As noted in issue #2, the current `Kaptan.get` returned a `{}` when the key did not exist. This version will raise a `KeyError` like the normal python dictionary.

I also added an optional `default` argument to `Kaptan.get` that is returned instead of raising `KeyError` if the given key does not exist.
