### PR TITLE
Simpler implementation of Kaptan.get

### DIFF
--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -1,10 +1,14 @@
 # -*- coding: utf8 -*-
+from collections import Mapping, Sequence
 
 from handlers.json_handler import JsonHandler
 from handlers.dict_handler import DictHandler
 from handlers.yaml_handler import YamlHandler
 from handlers.file_handler import FileHandler
 from handlers.ini_handler import IniHandler
+
+
+SENTINEL = object()
 
 
 class Kaptan(object):
@@ -29,30 +33,36 @@ class Kaptan(object):
         self.configuration_data = self.handler.load(value)
         return self
 
-    def get(self, key, default=None):
+    def _get(self, key):
         current_data = self.configuration_data
+
         for chunk in key.split('.'):
-            try:
-                current_data = current_data.get(chunk, {})
-            except AttributeError as error:
-                if isinstance(current_data, list):
-                    try:
-                        chunk = int(chunk)
-                    except ValueError:
-                        raise error
+            if isinstance(current_data, Mapping):
+                current_data = current_data[chunk]
+            elif isinstance(current_data, Sequence):
+                chunk = int(chunk)
 
-                    return current_data[chunk]
-                else:
-                    # for multi dimensional configs like foo.bar.baz
-                    if default:
-                        return default
-                    raise KeyError(key)
+                current_data = current_data[chunk]
+            else:
+                # A scalar type has been found
+                return current_data
 
-        if current_data == {}:
-            if default:
-                return default
-            raise KeyError(key)
         return current_data
+
+    def get(self, key, default=SENTINEL):
+        try:
+            try:
+                return self._get(key)
+            except (KeyError):
+                raise KeyError(key)
+            except (ValueError):
+                raise ValueError("Sequence index not an integer")
+            except (IndexError):
+                raise IndexError("Sequence index out of range")
+        except (KeyError, ValueError, IndexError):
+            if default is not SENTINEL:
+                return default
+            raise
 
     def export(self, handler=None):
         if not handler:
@@ -61,4 +71,3 @@ class Kaptan(object):
             handler_class = self.HANDLER_MAP[handler]()
 
         return handler_class.dump(self.configuration_data)
-


### PR DESCRIPTION
This patch does the following:
- Split up the function accessing the dictionary and the function
  handling errors. This way the first can be called by the second
  and error handling is easier.

The new dictionary access function now uses a more straightforward approach. This makes it more readable than the previous; And allows the implementation of the new feature mentioned below.
- **New feature:** Allowing of nested indices and key access. This way a key similar to `option.0.address` is legal to use. Arbitrary nesting of these is supported.

**Note:** I added more `Exceptions` that can be raised when calling `Kaptan.get`. I'm not very fond of this idea and I think we might want to change this to just `KeyError`'s instead. I think it might be too complex for the simplicity that _kaptan_ brings to the table.
