### PR TITLE
Add cli script

### DIFF
--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -85,3 +85,40 @@ class Kaptan(object):
             handler_class = self.HANDLER_MAP[handler]()
 
         return handler_class.dump(self.configuration_data)
+
+
+def main():
+    import argparse
+    import os
+    parser = argparse.ArgumentParser(
+        description='Configuration manager in your pocket')
+    parser.add_argument('config_file', action='store',
+                        help="file to load config from")
+    parser.add_argument('--handler', action='store',
+                        help="handler to use (default: guessed from filename)")
+    parser.add_argument('-e', '--export', action='store', default='json',
+                        help="format to export to")
+    parser.add_argument('-k', '--key', action='store',
+                        help="config key to get value of")
+    args = parser.parse_args()
+    HANDLER_EXT = {
+        'ini': 'ini',
+        'conf': 'ini',
+        'yaml': 'yaml',
+        'json': 'json',
+        'py': 'file',
+    }
+    handler = (args.handler or
+        HANDLER_EXT.get(
+            os.path.splitext(args.config_file)[1][1:],
+            None
+        ))
+    if not handler:
+        raise RuntimeError("Unable to determine handler")
+    with open(args.config_file) as f:
+        config = Kaptan(handler=handler)
+        config.import_config(f.read())
+    if args.key:
+        print config.get(args.key)
+    else:
+        print config.export(args.export)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='kaptan',
@@ -9,5 +9,10 @@ setup(
     author='Emre Yilmaz',
     author_email='mail@emreyilmaz.me',
     description='Configuration Manager',
-    requires=['PyYAML', ],
+    install_requires=['PyYAML', ],
+    entry_points=dict(
+        console_scripts=[
+            'kaptan = kaptan:main',
+        ],
+    ),
 )


### PR DESCRIPTION
Allows for parsing configuration in shell scripts:

``` sh
ping `kaptan config.yaml --key db.host`
```

or config conversion:

``` sh
kaptan config.yaml --export json > config.json
```

Tries to guess handler to use from file extension but you can specify it yourself:

``` sh
kaptan config --handler yaml
```
