### PR TITLE
.get() for full config, kwargs for export() YAML and JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ redis_uri: redis://localhost:6379/0
 ```python
 print config.export("json")
 ```
+
+output unindented json. ``.export`` accepts kwargs which pass into [json.dumps](http://docs.python.org/2/library/json.html#json.dump).
+
+```python
+print config.export("json", indent=4)
+```
+
 **output**:
 ```
 {
@@ -153,6 +160,9 @@ print config.export("json")
     "redis_uri": "redis://localhost:6379/0"
 }
 ```
+
+``config.export('yaml')`` also supports the [kwargs for pyyaml](http://pyyaml.org/wiki/PyYAMLDocumentation#Dumper).
+
 ## cli ##
 exporting (defaults to json)
 ```

--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -72,7 +72,10 @@ class Kaptan(object):
 
         return current_data
 
-    def get(self, key, default=SENTINEL):
+    def get(self, key=None, default=SENTINEL):
+        if not key:  # .get() or .get(''), return full config
+            return self.export('dict')
+
         try:
             try:
                 return self._get(key)
@@ -87,13 +90,13 @@ class Kaptan(object):
                 return default
             raise
 
-    def export(self, handler=None):
+    def export(self, handler=None, **kwargs):
         if not handler:
             handler_class = self.handler
         else:
             handler_class = self.HANDLER_MAP[handler]()
 
-        return handler_class.dump(self.configuration_data)
+        return handler_class.dump(self.configuration_data, **kwargs)
 
     def __handle_default_value(self, key, default):
         if default == SENTINEL:

--- a/kaptan/handlers/json_handler.py
+++ b/kaptan/handlers/json_handler.py
@@ -9,5 +9,5 @@ class JsonHandler(BaseHandler):
     def load(self, data):
         return json.loads(data)
 
-    def dump(self, data):
-        return json.dumps(data)
+    def dump(self, data, **kwargs):
+        return json.dumps(data, **kwargs)

--- a/kaptan/handlers/yaml_handler.py
+++ b/kaptan/handlers/yaml_handler.py
@@ -9,5 +9,5 @@ class YamlHandler(BaseHandler):
     def load(self, data):
         return yaml.load(data)
 
-    def dump(self, data):
-        return yaml.dump(data)
+    def dump(self, data, **kwargs):
+        return yaml.dump(data, **kwargs)

--- a/tests.py
+++ b/tests.py
@@ -94,7 +94,6 @@ class KaptanTests(unittest.TestCase):
 
         config = kaptan.Kaptan(handler='json')
         config.import_config(json_file.name)
-        print(config.get('production'))
         self.assertEqual(
             config.get("production.DATABASE_URI"),
             'mysql://poor_user:poor_password@localhost/poor_posts'
@@ -119,7 +118,6 @@ production:
 
         config = kaptan.Kaptan(handler='yaml')
         config.import_config(yaml_file.name)
-        print(config.get('production'))
         self.assertEqual(
             config.get("production.DATABASE_URI"),
             'mysql://poor_user:poor_password@localhost/poor_posts'
@@ -205,6 +203,9 @@ PAGINATION = {
         self.assertEqual(config.get("invalid_key", None), None)
         self.assertEqual(config.get("invalid_key.bar.baz", None), None)
 
+    def test_get_all_config(self):
+        config = kaptan.Kaptan()
+        config.import_config(self.__get_config_data())
 
-
-
+        self.assertIsInstance(config.get(), dict)
+        self.assertIsInstance(config.get(''), dict)


### PR DESCRIPTION
Currently, my json exports are unindented on a single line. This adds support for adding kwargs to include an indent.

kwargs in dumping pyyaml and json:

pyyaml.dump: http://pyyaml.org/wiki/PyYAMLDocumentation#Dumper
json.dump/dumps: http://docs.python.org/2/library/json.html#json.dump

`config.get()` and `.config.get('')` return the whole config, equivalent to `config.export('dict')`.
