### PR TITLE
add and remove methods added

### DIFF
--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -156,7 +156,7 @@ class Kaptan(object):
 
         return self
 
-    def remove(self, key=None):
+    def remove(self, key=None, index=None):
         if not key:
             raise RuntimeError("Unable to find key")
 
@@ -168,7 +168,10 @@ class Kaptan(object):
             del keys[-1]
         for chunk in keys:
             current_data = current_data[chunk]
-        del current_data[exact_key]
+        if isinstance(index, int) and isinstance(current_data[exact_key], list):
+            current_data[exact_key].pop(index)
+        else:
+            del current_data[exact_key]
 
         return self
 

--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -138,7 +138,8 @@ class Kaptan(object):
                         is_key_exist = True
                     current_data = current_data[chunk]
                 except KeyError:
-                    current_data = {}
+                    current_data[chunk] = {}
+                    current_data = current_data[chunk]
         try:
             if replace:
                 current_data[new_key] = value

--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -125,25 +125,20 @@ class Kaptan(object):
                 return default
             raise
 
-    def add(self, key=None, value=None, replace=False):
-        if not key:
-            raise RuntimeError("Unable to find key")
-
+    def add(self, key, value=None, replace=False):
         current_data = self.configuration_data
         keys = key.split('.')
         new_key = keys[0]
         is_key_exist = False
         if len(keys) > 1:
-            new_key = keys[-1]
-            del keys[-1]
+            new_key = keys.pop()
             for chunk in keys:
                 try:
                     if not replace and new_key in current_data[chunk]:
                         is_key_exist = True
                     current_data = current_data[chunk]
                 except KeyError:
-                    current_data[chunk] = {}
-                    current_data = current_data[chunk]
+                    current_data = {}
         try:
             if replace:
                 current_data[new_key] = value
@@ -156,16 +151,12 @@ class Kaptan(object):
 
         return self
 
-    def remove(self, key=None, index=None):
-        if not key:
-            raise RuntimeError("Unable to find key")
-
+    def remove(self, key, index=None):
         current_data = self.configuration_data
         keys = key.split('.')
         exact_key = keys[0]
         if len(keys) > 1:
-            exact_key = keys[-1]
-            del keys[-1]
+            exact_key = keys.pop()
         for chunk in keys:
             current_data = current_data[chunk]
         if isinstance(index, int) and isinstance(current_data[exact_key], list):

--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -125,6 +125,53 @@ class Kaptan(object):
                 return default
             raise
 
+    def add(self, key=None, value=None, replace=False):
+        if not key:
+            raise RuntimeError("Unable to find key")
+
+        current_data = self.configuration_data
+        keys = key.split('.')
+        new_key = keys[0]
+        is_key_exist = False
+        if len(keys) > 1:
+            new_key = keys[-1]
+            del keys[-1]
+            for chunk in keys:
+                try:
+                    if not replace and new_key in current_data[chunk]:
+                        is_key_exist = True
+                    current_data = current_data[chunk]
+                except KeyError:
+                    current_data[chunk] = {}
+                    current_data = current_data[chunk]
+        try:
+            if replace:
+                current_data[new_key] = value
+            elif isinstance(current_data[new_key], list):
+                current_data[new_key].append(value)
+            elif is_key_exist:
+                raise RuntimeError("Key %s already exist" % new_key)
+        except KeyError as e:
+            current_data[new_key] = value
+
+        return self
+
+    def remove(self, key=None):
+        if not key:
+            raise RuntimeError("Unable to find key")
+
+        current_data = self.configuration_data
+        keys = key.split('.')
+        exact_key = keys[0]
+        if len(keys) > 1:
+            exact_key = keys[-1]
+            del keys[-1]
+        for chunk in keys:
+            current_data = current_data[chunk]
+        del current_data[exact_key]
+
+        return self
+
     def export(self, handler=None, **kwargs):
         if not handler:
             handler_class = self.handler

--- a/tests/test_kaptan.py
+++ b/tests/test_kaptan.py
@@ -139,6 +139,18 @@ def test_remove_key_from_configuration():
     assert config.get('server') == {'name': 'redis'}
 
 
+def test_remove_item_from_array_on_configuration():
+    config = kaptan.Kaptan()
+    config.import_config({
+        'price': {
+            'currencies': ['TL', 'EUR', 'USD']
+        }
+    })
+    config.remove('price.currencies', 1)
+
+    assert config.get('price.currencies') == ['TL', 'USD']
+
+
 def test_upsert(testconfig):
     config = kaptan.Kaptan()
     config.import_config(testconfig)

--- a/tests/test_kaptan.py
+++ b/tests/test_kaptan.py
@@ -86,6 +86,59 @@ def test_lists_on_configuration():
     assert config.get('servers.0') == 'redis1'
 
 
+def test_add_to_configuration():
+    config = kaptan.Kaptan()
+    config.import_config({
+        'server': 'redis'
+    })
+    config.add('uptime', 99.9)
+
+    assert config.get('uptime') == 99.9
+
+
+def test_add_to_list_on_configuration():
+    config = kaptan.Kaptan()
+    config.import_config({
+        'servers': ['redis1', 'redis2', 'redis3'],
+    })
+    config.add('servers', 'redis4')
+
+    assert config.get('servers.3') == 'redis4'
+
+
+def test_replace_key_on_configuration():
+    config = kaptan.Kaptan()
+    config.import_config({
+        'price': 22
+    })
+    config.add('price', 12.5, True)
+
+    assert config.get('price') == 12.5
+
+
+def test_add_key_with_parent_on_configuration():
+    config = kaptan.Kaptan()
+    config.import_config({
+        'product': 'Test'
+    })
+    config.add('price.currency.name', 'TL')
+
+    assert config.get('price.currency.name') == 'TL'
+
+
+def test_remove_key_from_configuration():
+    config = kaptan.Kaptan()
+    config.import_config({
+        'server': {
+            'name': 'redis',
+            'status': True
+        }
+    })
+    config.remove('server.status')
+
+    assert config.get('server') == {'name': 'redis'}
+
+
 def test_upsert(testconfig):
     config = kaptan.Kaptan()
     config.import_config(testconfig)


### PR DESCRIPTION
With this PR, 2 methods which are `add` and `remove` added to Kaptan.
- `add`: Adds a key-value pair to the current data.

Current data: `{'product': {'price': 1.25, 'currencies': ['TL', 'EUR']}}`

with `.add('product.isPaid', True)` it changes to: `{'product': {'price': 1.25, 'currencies': ['TL', 'EUR'], 'isPaid': true}}`

with `.add('product.currencies', 'USD')` it changes to: `{'product': {'price': 1.25, 'currencies': ['TL', 'EUR', 'USD']}}`

with `.add('product.price', 22)` it raises error like `Key price already exist`

with `.add('product.price', 22, True)` it replaces `price` value. So, last parameter is to replace.
- `remove`: Removes a key from the current data.

with `.remove('product.currencies')` it changes to: `{'product': {'price': 1.25}}`

with `.remove('product.currencies', 0)` it changes to: `{'product': {'price': 1.25, 'currencies': ['EUR']}}`. If last parameter given, it refers index of an array.
