### PR TITLE
Update collections abc import for Python 3.8 compatibility

### DIFF
--- a/kaptan/__init__.py
+++ b/kaptan/__init__.py
@@ -13,8 +13,8 @@ from __future__ import print_function, unicode_literals
 
 import argparse
 import os
-from collections import Mapping, Sequence
 
+from ._compat import collections_abc
 from .handlers.dict_handler import DictHandler
 from .handlers.pyfile_handler import PyFileHandler
 from .handlers.ini_handler import IniHandler
@@ -95,9 +95,9 @@ class Kaptan(object):
         current_data = self.configuration_data
 
         for chunk in key.split('.'):
-            if isinstance(current_data, Mapping):
+            if isinstance(current_data, collections_abc.Mapping):
                 current_data = current_data[chunk]
-            elif isinstance(current_data, Sequence):
+            elif isinstance(current_data, collections_abc.Sequence):
                 chunk = int(chunk)
 
                 current_data = current_data[chunk]
@@ -162,7 +162,6 @@ def get_parser():
 
 def main():
     from sys import stdin
-    from collections import OrderedDict
 
     parser = get_parser()
     args, ukargs = parser.parse_known_args()
@@ -181,7 +180,7 @@ def main():
                 s += [None]
             yield tuple(s)
 
-    config_handlers = OrderedDict(list(get_handlers()))
+    config_handlers = collections_abc.OrderedDict(list(get_handlers()))
 
     for config_file, handler in config_handlers.items():
         is_stdin = config_file == '-'

--- a/kaptan/_compat.py
+++ b/kaptan/_compat.py
@@ -1,0 +1,11 @@
+# -*- coding: utf8 -*-
+# flake8: NOQA: F40
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    import collections as collections_abc
+else:
+    import collections.abc as collections_abc


### PR DESCRIPTION
pytest raises this:

DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated, and in 3.8 it will stop
working

See also: https://github.com/pallets/werkzeug/commit/759aa683